### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,4 +1,6 @@
 name: PR Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/RichmanTanOrganisation/jobs-board/security/code-scanning/1](https://github.com/RichmanTanOrganisation/jobs-board/security/code-scanning/1)

To address the issue, add a `permissions` block specifying the minimal set of required permissions for this workflow/job. The best way is to set it at the job level or root level, as appropriate. Since the workflow only checks out code and runs builds, the steps only need read access to repository contents, which is granted by `contents: read`. Place the `permissions` block either directly below `name:` (for workflow-wide effect) or immediately under the `build:` job (for job-level effect); setting it at the workflow root is typically best if all jobs use the same permissions. No new imports or methods are needed; simply add:

```yaml
permissions:
  contents: read
```

right after the workflow `name:` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
